### PR TITLE
Implement an always failing version of stime.

### DIFF
--- a/arch/wasm32/js/wasm.js
+++ b/arch/wasm32/js/wasm.js
@@ -191,8 +191,8 @@ syscall_fns = {
   },
   25: {
     name: "SYS_stime",
-    fn: function() {
-      throw "SYS_stime NYI";
+    fn: function(t) {
+      return -1; // EPERM
     }
   },
   26: {


### PR DESCRIPTION
Does this look alright? There wasn't much information to go on when it comes to implementing these syscalls.

It always fails with EPERM since it's impossible to adjust the system time from JS (is it?).

The file errno.h should probably be converted to JS too.